### PR TITLE
fix: retrieve only domain entities generated with jhipster

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -114,7 +114,7 @@ module.exports = class extends BaseGenerator {
         try {
             existingEntityNames = fsModule.readdirSync('.jhipster');
         } catch (e) {
-            this.log("Error when reading entities folder : .jhipster");
+            this.log('Error when reading entities folder : .jhipster');
         }
         existingEntityNames.forEach(entry => {
             if (entry.indexOf('.json') !== -1) {

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -1,5 +1,4 @@
 const chalk = require('chalk');
-const shelljs = require('shelljs');
 const _ = require('lodash');
 const semver = require('semver');
 const BaseGenerator = require('generator-jhipster/generators/generator-base');
@@ -110,16 +109,14 @@ module.exports = class extends BaseGenerator {
             name: 'Producer',
             value: 'producer'
         });
-
-  
+        
         const entitiesChoices = [];
         let existingEntityNames = [];
         try {
           existingEntityNames = fsModule.readdirSync('.jhipster');
         } catch (e) {
-          
+            this.log(`\nError when reading entities folder : .jhipster`);
         }
-
         existingEntityNames.forEach((entry) => {
           if (entry.indexOf('.json') !== -1) {
             const entityName = entry.replace('.json', '');
@@ -129,8 +126,6 @@ module.exports = class extends BaseGenerator {
             });
           }
         });
-        
-        
         const defaultValues = this.extractDefaultPromptValues(this.getPreviousKafkaConfiguration(), componentsChoices);
 
         const prompts = [

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -111,26 +111,26 @@ module.exports = class extends BaseGenerator {
             value: 'producer'
         });
 
-        const domainClassesPath = `${jhipsterConstants.SERVER_MAIN_SRC_DIR + this.jhipsterAppConfig.packageFolder}/domain`;
-        const files = shelljs.ls(`${domainClassesPath}/*.java`);
-
+  
         const entitiesChoices = [];
-        files.forEach(file => {
-            if (shelljs.grep(/^@Entity$/, file) !== '') {
-                const className = file
-                    .split('.')
-                    .slice(0, -1)
-                    .join('.')
-                    .match(/\w*$/i);
-                if (className) {
-                    entitiesChoices.push({
-                        name: className[0],
-                        value: className[0]
-                    });
-                }
-            }
-        });
+        let existingEntityNames = [];
+        try {
+          existingEntityNames = fsModule.readdirSync('.jhipster');
+        } catch (e) {
+          
+        }
 
+        existingEntityNames.forEach((entry) => {
+          if (entry.indexOf('.json') !== -1) {
+            const entityName = entry.replace('.json', '');
+              entitiesChoices.push({
+              name: entityName,
+              value: entityName
+            });
+          }
+        });
+        
+        
         const defaultValues = this.extractDefaultPromptValues(this.getPreviousKafkaConfiguration(), componentsChoices);
 
         const prompts = [

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -109,22 +109,21 @@ module.exports = class extends BaseGenerator {
             name: 'Producer',
             value: 'producer'
         });
-        
         const entitiesChoices = [];
         let existingEntityNames = [];
         try {
-          existingEntityNames = fsModule.readdirSync('.jhipster');
+            existingEntityNames = fsModule.readdirSync('.jhipster');
         } catch (e) {
-            this.log(`\nError when reading entities folder : .jhipster`);
+            this.log("Error when reading entities folder : .jhipster");
         }
-        existingEntityNames.forEach((entry) => {
-          if (entry.indexOf('.json') !== -1) {
-            const entityName = entry.replace('.json', '');
-              entitiesChoices.push({
-              name: entityName,
-              value: entityName
-            });
-          }
+        existingEntityNames.forEach(entry => {
+            if (entry.indexOf('.json') !== -1) {
+                const entityName = entry.replace('.json', '');
+                entitiesChoices.push({
+                    name: entityName,
+                    value: entityName
+                });
+            }
         });
         const defaultValues = this.extractDefaultPromptValues(this.getPreviousKafkaConfiguration(), componentsChoices);
 


### PR DESCRIPTION
This part of code allow to retrieve all domain entities generated by jhipster.
Original code before, can only retrieve Entity used in sql db (@Entity). When having entity in mongodb for instance, the class annotation si @Document .

- Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/fdelbrayelle/generator-jhipster-kafka/actions) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/fdelbrayelle/generator-jhipster-kafka/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
