### PR TITLE
fix: remove links in docker-compose file for akhq

### DIFF
--- a/generators/app/templates/src/main/docker/akhq.yml.ejs
+++ b/generators/app/templates/src/main/docker/akhq.yml.ejs
@@ -11,5 +11,3 @@ services:
                 bootstrap.servers: "kafka:29092"
     ports:
       - 11817:8080
-    links:
-      - kafka


### PR DESCRIPTION
It's for fixing:

```
➜ docker-compose -f src/main/docker/akhq.yml up -d
ERROR: Service 'akhq' has a link to service 'kafka' which is undefined.
```


- Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/fdelbrayelle/generator-jhipster-kafka/actions) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/fdelbrayelle/generator-jhipster-kafka/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
